### PR TITLE
Markup adjustments

### DIFF
--- a/public/503.html
+++ b/public/503.html
@@ -97,19 +97,16 @@
     </div>
   </header>
 
-  <div id="wrapper" class="govuk-width-container group">
-    <main id="content" role="main" class="group">
-      <header class="page-header group">
-        <div>
-          <h1>There's a problem with the GOV.UK Account service</h1>
+  <div id="wrapper" class="govuk-width-container">
+    <main id="content" role="main" class="govuk-main-wrapper govuk-main-wrapper--l">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-l">There's a problem with the GOV.UK Account service</h1>
+          <p class="govuk-body">Try again later</p>
+          <p class="govuk-body">Go to the <a class="govuk-link" href="https://www.gov.uk/transition">Brexit page</a> to find out what you need to do differently now that the UK has left the EU. </a></p>
+          <br>
+          <pre>Status code: 503</pre>
         </div>
-      </header>
-      <div class="article-container govuk-!-margin-bottom-9">
-        <p>Try again later</p>
-        <p>Go to the <a class="govuk-link" href="https://www.gov.uk/transition">Brexit page</a> to find out what you need to do differently now that the UK has left the EU. </a>
-        </p>
-        <br>
-        <pre>Status code: 503</pre>
       </div>
 
       <script type="text/javascript">


### PR DESCRIPTION
Update the `503` page markup to more closely match the Design system layout for [Service unavailable pages](https://design-system.service.gov.uk/patterns/service-unavailable-pages/).

The copy is now contained inside a `two-thirds` column. Additionally, there should be more space between the page header and the content, which were previously very close together on mobile.


https://trello.com/c/Mmv4gF5o/656-review-the-error-page-templates